### PR TITLE
Fixes #1 -config vercel to include the swagger-ui-dist from node_modules

### DIFF
--- a/vercel.json
+++ b/vercel.json
@@ -4,7 +4,7 @@
         {
             "src": "dist/app.js",
             "use": "@vercel/node",
-            "config": { "includeFiles": ["dist/**"] }
+            "config": { "includeFiles": ["dist/**","./node_modules/swagger-ui-dist/**"] }
         }
     ],
     "routes": [


### PR DESCRIPTION
The errors in the console was due to vercel being unable to find the swagger-ui-dist(subdepdency of swagger-ui-express), so explicitly configed to include that during the build process.
Which resolved the syntax and undefined bundle error.